### PR TITLE
Query string and site resolving fixes, exception trapping

### DIFF
--- a/website/Pipelines.HttpRequest/ItemRedirect/ItemRedirectResolver.cs
+++ b/website/Pipelines.HttpRequest/ItemRedirect/ItemRedirectResolver.cs
@@ -51,11 +51,11 @@ namespace LiquidSC.Foundation.RedirectManager.Pipelines.HttpRequest
 
                     if (resolvedMapping.RedirectType == RedirectType.Redirect301)
                     {
-                        this.Redirect301(HttpContext.Current.Response, resolvedMapping.Target);
+                        this.Redirect301(HttpContext.Current, resolvedMapping.Target);
                     }
                     else if (resolvedMapping.RedirectType == RedirectType.Redirect302)
                     {
-                        HttpContext.Current.Response.Redirect(resolvedMapping.Target, true);
+                        this.Redirect302(HttpContext.Current, resolvedMapping.Target);
                     }
                     else if (resolvedMapping.RedirectType == RedirectType.ServerTransfer)
                     {
@@ -64,7 +64,7 @@ namespace LiquidSC.Foundation.RedirectManager.Pipelines.HttpRequest
                     //default to 302
                     else
                     {
-                        HttpContext.Current.Response.Redirect(resolvedMapping.Target, true);
+                        this.Redirect302(HttpContext.Current, resolvedMapping.Target);
                     }
 
                     args.AbortPipeline();

--- a/website/Pipelines.HttpRequest/PathRedirect/PathRedirectResolver.cs
+++ b/website/Pipelines.HttpRequest/PathRedirect/PathRedirectResolver.cs
@@ -53,11 +53,11 @@ namespace LiquidSC.Foundation.RedirectManager.Pipelines.HttpRequest
 
                     if (resolvedMapping.RedirectType == RedirectType.Redirect301)
                     {
-                        this.Redirect301(HttpContext.Current.Response, resolvedMapping.Target);
+                        this.Redirect301(HttpContext.Current, resolvedMapping.Target);
                     }
                     else if (resolvedMapping.RedirectType == RedirectType.Redirect302)
                     {
-                        HttpContext.Current.Response.Redirect(resolvedMapping.Target, true);
+                        this.Redirect302(HttpContext.Current, resolvedMapping.Target);
                     }
                     else if (resolvedMapping.RedirectType == RedirectType.ServerTransfer)
                     {
@@ -66,7 +66,7 @@ namespace LiquidSC.Foundation.RedirectManager.Pipelines.HttpRequest
                     //default to 302
                     else
                     {
-                        HttpContext.Current.Response.Redirect(resolvedMapping.Target, true);
+                        this.Redirect302(HttpContext.Current, resolvedMapping.Target);
                     }
 
                     args.AbortPipeline();

--- a/website/Pipelines.HttpRequest/RedirectMap/RedirectMapResolver.cs
+++ b/website/Pipelines.HttpRequest/RedirectMap/RedirectMapResolver.cs
@@ -50,11 +50,11 @@ namespace LiquidSC.Foundation.RedirectManager.Pipelines.HttpRequest
                 string targetUrl = this.GetTargetUrl(resolvedMapping, requestedPath);
                 if (resolvedMapping.RedirectType == RedirectType.Redirect301)
                 {
-                    this.Redirect301(HttpContext.Current.Response, targetUrl);
+                    this.Redirect301(HttpContext.Current, targetUrl);
                 }
                 else if (resolvedMapping.RedirectType == RedirectType.Redirect302)
                 {
-                    HttpContext.Current.Response.Redirect(targetUrl, true);
+                    this.Redirect302(HttpContext.Current, targetUrl);
                 }
                 else if (resolvedMapping.RedirectType == RedirectType.ServerTransfer)
                 {
@@ -62,7 +62,7 @@ namespace LiquidSC.Foundation.RedirectManager.Pipelines.HttpRequest
                 }
                 else
                 {
-                    HttpContext.Current.Response.Redirect(targetUrl, true);
+                    this.Redirect302(HttpContext.Current, targetUrl);
                 }
             }
         }


### PR DESCRIPTION
- Fixed query string infinite (re)appending;
- Properly resolved links to items on different sites; 
- Prevented `System.Threading.ThreadAbortException` on 301 & 302 redirects.